### PR TITLE
add missing ADDRESS_FAMILY typedef to fix linux build

### DIFF
--- a/src/CashDB.Client/compat.h
+++ b/src/CashDB.Client/compat.h
@@ -41,6 +41,7 @@
 #endif
 
 #ifndef _WIN32
+typedef sa_family_t ADDRESS_FAMILY;
 typedef unsigned int SOCKET;
 #define closesocket close
 #include "errno.h"


### PR DESCRIPTION
Inside `src/CashDB.Client/connection.c` there is use of `ADDRESS_FAMILY` but the type does not exist. I was able to find it inside lmdb's compat.h and added the typedef to the CashDB.Client compat. 